### PR TITLE
Add TCP Commnications

### DIFF
--- a/radio.go
+++ b/radio.go
@@ -27,16 +27,14 @@ const broadcastNum = 0xffffffff
 
 // Radio holds the port and serial io.ReadWriteCloser struct to maintain one serial connection
 type Radio struct {
-	portNumber string
-	serialPort io.ReadWriteCloser
-	streamer   streamer
+	streamer streamer
 }
 
 // Init initializes the Serial connection for the radio
-func (r *Radio) Init(port string, isTCP bool) error {
+func (r *Radio) Init(port string) error {
 
 	streamer := streamer{}
-	err := streamer.Init(port, isTCP)
+	err := streamer.Init(port)
 	if err != nil {
 		return err
 	}

--- a/radio.go
+++ b/radio.go
@@ -6,12 +6,12 @@ import (
 	"errors"
 	"io"
 	"math/rand"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/jacobsa/go-serial/serial"
 	pb "github.com/lmatte7/gomesh/github.com/meshtastic/gomeshproto"
 	"google.golang.org/protobuf/proto"
 )
@@ -29,29 +29,18 @@ const broadcastNum = 0xffffffff
 type Radio struct {
 	portNumber string
 	serialPort io.ReadWriteCloser
+	streamer   streamer
 }
 
 // Init initializes the Serial connection for the radio
-func (r *Radio) Init(serialPort string) error {
-	r.portNumber = serialPort
-	//Configure the serial port
-	options := serial.OpenOptions{
-		PortName:              r.portNumber,
-		BaudRate:              921600,
-		DataBits:              8,
-		StopBits:              1,
-		MinimumReadSize:       0,
-		InterCharacterTimeout: 100,
-		ParityMode:            serial.PARITY_NONE,
-	}
+func (r *Radio) Init(port string, isTCP bool) error {
 
-	// Open the port.
-	port, err := serial.Open(options)
+	streamer := streamer{}
+	err := streamer.Init(port, isTCP)
 	if err != nil {
 		return err
 	}
-
-	r.serialPort = port
+	r.streamer = streamer
 
 	return nil
 }
@@ -64,12 +53,10 @@ func (r *Radio) sendPacket(protobufPacket []byte) (err error) {
 	header := []byte{start1, start2, byte(packageLength>>8) & 0xff, byte(packageLength) & 0xff}
 
 	radioPacket := append(header, protobufPacket...)
-	_, err = r.serialPort.Write(radioPacket)
+	err = r.streamer.Write(radioPacket)
 	if err != nil {
 		return err
 	}
-
-	time.Sleep(100 * time.Millisecond)
 
 	return
 
@@ -93,7 +80,7 @@ func (r *Radio) ReadResponse() (FromRadioPackets []*pb.FromRadio, err error) {
 	* bytes is equal to the packet length plus the header
 	 */
 	for {
-		_, err := r.serialPort.Read(b)
+		err := r.streamer.Read(b)
 		// fmt.Printf("Byte: %q\n", b)
 		if bytes.Equal(b, previousByte) {
 			repeatByteCounter++
@@ -101,7 +88,7 @@ func (r *Radio) ReadResponse() (FromRadioPackets []*pb.FromRadio, err error) {
 			repeatByteCounter = 0
 		}
 
-		if err == io.EOF || repeatByteCounter > 20 {
+		if err == io.EOF || repeatByteCounter > 20 || errors.Is(err, os.ErrDeadlineExceeded) {
 			break
 		} else if err != nil {
 			return nil, err
@@ -866,7 +853,5 @@ func (r *Radio) SetLocation(lat float64, long float64, alt int32) error {
 
 // Close closes the serial port. Added so users can defer the close after opening
 func (r *Radio) Close() {
-	if r.serialPort != nil {
-		r.serialPort.Close()
-	}
+	r.streamer.Close()
 }

--- a/radio_test.go
+++ b/radio_test.go
@@ -317,8 +317,8 @@ func TestSetLocation(t *testing.T) {
 
 func radioSetup() (radio Radio, err error) {
 	radio = Radio{}
-	err = radio.Init("192.168.86.40", true)
-	// err = radio.Init("/dev/cu.SLAB_USBtoUART", false)
+	// err = radio.Init("192.168.86.40")
+	err = radio.Init("/dev/cu.SLAB_USBtoUART")
 	if err != nil {
 		return Radio{}, err
 	}

--- a/radio_test.go
+++ b/radio_test.go
@@ -154,19 +154,24 @@ func TestSetRadioPref(t *testing.T) {
 	}
 	defer radio.Close()
 
-	err = radio.SetUserPreferences("WifiApMode", "true")
+	err = radio.SetUserPreferences("SendOwnerInterval", "20")
 	if err != nil {
 		t.Fatalf("Error setting preference: %v", err)
 	}
 
+	// time.Sleep(3 * time.Second)
 	radioPrefs, err := radio.GetRadioPreferences()
 
 	if err != nil {
 		t.Fatalf("Error when opening serial communications with radio: %v", err)
 	}
 
-	if radioPrefs.GetGetRadioResponse().Preferences.GetWifiApMode() != true {
+	if radioPrefs.GetGetRadioResponse().Preferences.GetSendOwnerInterval() != 20 {
 		t.Fatalf("Radio Preference Not Set Correctly")
+	}
+	err = radio.SetUserPreferences("SendOwnerInterval", "0")
+	if err != nil {
+		t.Fatalf("Error setting preference: %v", err)
 	}
 
 }
@@ -312,7 +317,8 @@ func TestSetLocation(t *testing.T) {
 
 func radioSetup() (radio Radio, err error) {
 	radio = Radio{}
-	err = radio.Init("/dev/cu.SLAB_USBtoUART")
+	err = radio.Init("192.168.86.40", true)
+	// err = radio.Init("/dev/cu.SLAB_USBtoUART", false)
 	if err != nil {
 		return Radio{}, err
 	}

--- a/streamer.go
+++ b/streamer.go
@@ -1,0 +1,101 @@
+package gomesh
+
+import (
+	"io"
+	"net"
+	"time"
+
+	"github.com/jacobsa/go-serial/serial"
+)
+
+type streamer struct {
+	serialPort io.ReadWriteCloser
+	netPort    net.Conn
+	isTCP      bool
+}
+
+func (s *streamer) Init(addr string, isTCP bool) error {
+
+	s.isTCP = isTCP
+
+	if isTCP {
+		ip := net.ParseIP(addr)
+		tcpAddr := net.TCPAddr{IP: ip, Port: 4403}
+		conn, err := net.DialTCP("tcp", nil, &tcpAddr)
+		if err != nil {
+			return err
+		}
+		s.netPort = conn
+
+	} else {
+		//Configure the serial port
+		options := serial.OpenOptions{
+			PortName:              addr,
+			BaudRate:              921600,
+			DataBits:              8,
+			StopBits:              1,
+			MinimumReadSize:       0,
+			InterCharacterTimeout: 100,
+			ParityMode:            serial.PARITY_NONE,
+		}
+
+		// Open the port.
+		port, err := serial.Open(options)
+		if err != nil {
+			return err
+		}
+
+		s.serialPort = port
+
+		return nil
+	}
+
+	return nil
+}
+
+func (s *streamer) Write(p []byte) error {
+
+	if s.isTCP {
+		s.netPort.SetReadDeadline(time.Now().Add(1 * time.Second))
+		_, err := s.netPort.Write(p)
+		if err != nil {
+			return err
+		}
+	} else {
+		_, err := s.serialPort.Write(p)
+		if err != nil {
+			return err
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return nil
+}
+
+func (s *streamer) Read(p []byte) error {
+
+	if s.isTCP {
+		s.netPort.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, err := s.netPort.Read(p)
+		if err != nil {
+			return err
+		}
+	} else {
+		_, err := s.serialPort.Read(p)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
+}
+
+func (s *streamer) Close() {
+	if s.isTCP {
+		s.netPort.Close()
+	} else {
+		s.serialPort.Close()
+	}
+}

--- a/streamer.go
+++ b/streamer.go
@@ -14,18 +14,18 @@ type streamer struct {
 	isTCP      bool
 }
 
-func (s *streamer) Init(addr string, isTCP bool) error {
+func (s *streamer) Init(addr string) error {
 
-	s.isTCP = isTCP
+	ip := net.ParseIP(addr)
 
-	if isTCP {
-		ip := net.ParseIP(addr)
+	if ip != nil {
 		tcpAddr := net.TCPAddr{IP: ip, Port: 4403}
 		conn, err := net.DialTCP("tcp", nil, &tcpAddr)
 		if err != nil {
 			return err
 		}
 		s.netPort = conn
+		s.isTCP = true
 
 	} else {
 		//Configure the serial port
@@ -46,6 +46,7 @@ func (s *streamer) Init(addr string, isTCP bool) error {
 		}
 
 		s.serialPort = port
+		s.isTCP = false
 
 		return nil
 	}


### PR DESCRIPTION
This PR adds the ability to communicate with meshtastic radios over TCP. When creating running `Init()` the function will automatically use TCP communications if the address can be parsed into an IP. 