### PR TITLE
Remove extra parenthese

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ r := gomesh.Radio{}
 responses, err := r.GetRadioInfo()
 if err != nil {
   return err
-})
+}
 ```
 
 In this example the responses could then be read and processed by type to process the data.


### PR DESCRIPTION
Just a little typo. It make the copy/paste of the readme easier.