### PR TITLE
Fix bug when a large message triggers the repeat exit logic

### DIFF
--- a/radio.go
+++ b/radio.go
@@ -87,8 +87,10 @@ func (r *Radio) ReadResponse(timeout bool) (FromRadioPackets []*pb.FromRadio, er
 		} else {
 			repeatByteCounter = 0
 		}
+		// Only break on repeated bytes if we're not in the middle of reading a valid packet
+		shouldBreakOnRepeat := repeatByteCounter > 20 && (len(processedBytes) < headerLen)
 
-		if err == io.EOF || repeatByteCounter > 20 || errors.Is(err, os.ErrDeadlineExceeded) {
+		if err == io.EOF || shouldBreakOnRepeat || errors.Is(err, os.ErrDeadlineExceeded) {
 			break
 		} else if err != nil {
 			return nil, err


### PR DESCRIPTION
While debugging the packet length bug mentioned in https://github.com/lmatte7/goMesh/pull/17 I saw there was another bug where large messages would disappear if they triggered the repeated character logic. This logic is still needed for windows compatibility, so it was adjusted to not count repeats when we start processing packets 